### PR TITLE
✨ Adds paginated method for fetching all data

### DIFF
--- a/asaas_client/request.py
+++ b/asaas_client/request.py
@@ -28,6 +28,8 @@ class AsaasRequest:
         self._url_path = [base_url]
         self._url_path.extend(self.args)
 
+        self.client = httpx.Client(headers=headers)
+
     def _build_url(self) -> str:
         """
         Build the final URL for the request.
@@ -71,7 +73,7 @@ class AsaasRequest:
                 if headers:
                     self._update_headers(headers)
 
-                return httpx.Client(headers=self.headers).request(
+                return self.client.request(
                     method=resource,
                     url=self._build_url(),
                     data=body,
@@ -83,7 +85,7 @@ class AsaasRequest:
 
         elif resource == "paginated":
 
-            def make_request_paginated(query_params=None, headers=None):
+            def make_request_paginated(query_params={}, headers=None):
                 if headers:
                     self._update_headers(headers)
 
@@ -92,14 +94,14 @@ class AsaasRequest:
                 offset = 0
                 data = []
 
-                with httpx.Client(headers=self.headers) as client:
+                with self.client as client:
                     while True:
                         query_params["offset"] = offset
 
                         res = client.get(
                             url=self._build_url(),
                             headers=self.headers,
-                            params=query_params,
+                            params=query_params.copy(),
                         )
 
                         res_json = res.json()

--- a/asaas_client/request.py
+++ b/asaas_client/request.py
@@ -107,7 +107,7 @@ class AsaasRequest:
                         res_json = res.json()
                         data.extend(res_json.get("data"))
 
-                        if res_json.get("hasMore") == False:
+                        if not res_json.get("hasMore"):
                             break
 
                         offset += self.DEFAULT_PAGE_LIMIT


### PR DESCRIPTION
This pull request adds a new method called `paginated` to the `AsaasRequest` class. This method allows for fetching all data from a paginated API endpoint by automatically handling pagination. It takes optional query parameters and headers as arguments and returns a list of all the data retrieved from the API.

The `paginated` method uses the `DEFAULT_PAGE_LIMIT` constant to set the page limit for each request. It starts with an offset of 0 and retrieves data in batches until there is no more data available. The retrieved data is then appended to a list and returned as the final result.

### Testing:
- Includes tests for the `make_request_paginated` .